### PR TITLE
Add PR workflows

### DIFF
--- a/.github/pull-request-labels.yml
+++ b/.github/pull-request-labels.yml
@@ -1,0 +1,5 @@
+Bugfix: [ 'bugfix/**', 'bug/**' ]
+Enhancement: [ 'feature/**', 'enhancement/**' ]
+Release: 'release/**'
+Platform: 'platform/**'
+documentation: 'documentation/**'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,35 @@
+name-template: 'v$RESOLVED_VERSION 🤓👩‍🎨'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'platform'
+  - title: '🧐 Documentation'
+    label: 'documentation'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+exclude-labels:
+  - 'Release'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/pr-automations.yml
+++ b/.github/workflows/pr-automations.yml
@@ -1,0 +1,18 @@
+name: Pull Request PlumDroid
+
+on:
+  pull_request:
+    types: [ opened, closed, ready_for_review, reopened ]
+
+jobs:
+  # Add labels based on branch name
+  add-branch-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add branch labels
+        if: ${{ github.event.action == 'opened' }}
+        uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pull-request-labels.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Compile Release Notes
+
+on:
+  push:
+    branches: [ 'master' ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds:
- Release drafter for compiling releases
  - THe version of each release is resolved [dynamically](https://github.com/release-drafter/release-drafter#version-resolver), based on the **labels** that the PRs have in a release (more specifically, `major`, `minor`, `patch`)
- PR labeler for adding labels to PRs

Of course, any suggestions for different tools/approach are more than welcome :bowtie: !