### PR TITLE
Use Material library BottomSheetBehavior

### DIFF
--- a/emojiBottomSheetDialog/src/main/res/layout/view_emoji_bottom_sheet.xml
+++ b/emojiBottomSheetDialog/src/main/res/layout/view_emoji_bottom_sheet.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <TextView
             android:id="@+id/tv_bottom_sheet_title"


### PR DESCRIPTION
Goal of this PR is to remove reference of `android-support` library and make use of Material Library. That will enable consumers of the library to not have to rely on Jetifier for transformations.