### PR TITLE
Add renovate for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Europe/Athens",
+  "schedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday",
+    "every weekend"
+  ],
+  "prHourlyLimit": 3,
+  "prConcurrentLimit": 5,
+  "updateNotScheduled": false,
+  "additionalReviewers": [
+    "team:android"
+  ],
+  "assignAutomerge": true,
+  "addLabels": [
+    "Dependency Updates"
+  ],
+  "ignorePaths": [
+    ".github/**"
+  ],
+  "major": {
+    "minimumReleaseAge": "30 days",
+    "internalChecksFilter": "strict",
+    "automerge": true
+  },
+  "minor": {
+    "minimumReleaseAge": "7 days",
+    "internalChecksFilter": "strict",
+    "automerge": true
+  },
+  "patch": {
+    "minimumReleaseAge": "1 days",
+    "internalChecksFilter": "strict",
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "groupName": "AGP and friends",
+      "matchPackageNames": [
+        "/com.android.library/",
+        "/com.android.application/",
+        "/com.android.tools.build:gradle/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description

This is about adding [Renovate](https://github.com/renovatebot/renovate) to this project for dependency updates to be handled automatically.

More specifically Renovate has been configured with these parameters:
- Updates are scheduled to happen overnight
- Auto-merge is enabled
- The label "Dependency Updates" will be added in relevant PRs. This label didn't exist, but has now been added to this project.
- Major versions have minimum release age of 30 days
- Minor versions have minimum release age of 7 days
- Patch versions have minimum release age of 1 day
